### PR TITLE
Support ircs as an protocol

### DIFF
--- a/application/parser/parselinks.cpp
+++ b/application/parser/parselinks.cpp
@@ -108,7 +108,7 @@ void ParseLinks::replaceUrls(QTextDocument *pRawDoc) {
 // External links [https://www.ubuntu.com]
 void ParseLinks::replaceHyperlinks(QTextDocument *pRawDoc) {
   QRegularExpression findHyperlink(
-        QString::fromLatin1("\\[{1,1}\\b(http|https|ftp|ftps|file|ssh|mms|svn"
+        QString::fromLatin1("\\[{1,1}\\b(https?|ftps?|file|ssh|mms|svn"
                             "|git|dict|nntp|ircs?|rsync|smb|apt)\\b://"));
   QString sDoc(pRawDoc->toPlainText());
   QRegularExpressionMatch match;

--- a/application/parser/parselinks.cpp
+++ b/application/parser/parselinks.cpp
@@ -73,7 +73,7 @@ void ParseLinks::startParsing(QTextDocument *pRawDoc) {
 void ParseLinks::replaceUrls(QTextDocument *pRawDoc) {
   QRegularExpression findUrl(
         QString::fromLatin1(
-          "(?:(?:https?|ftps?|file|ssh|mms|svn(?:\\+ssh)?|git|dict|nntp|irc|"
+          "(?:(?:https?|ftps?|file|ssh|mms|svn(?:\\+ssh)?|git|dict|nntp|ircs?|"
           "rsync|smb|apt)://)[^\[\\s\\]]+(/[^\\s\\].,:;?]*([.,:;?]"
           "[^\\s\\].,:;?]+)*)?[^\\]\\)\\\\\\s]"));
   QString sDoc(pRawDoc->toPlainText());
@@ -109,7 +109,7 @@ void ParseLinks::replaceUrls(QTextDocument *pRawDoc) {
 void ParseLinks::replaceHyperlinks(QTextDocument *pRawDoc) {
   QRegularExpression findHyperlink(
         QString::fromLatin1("\\[{1,1}\\b(http|https|ftp|ftps|file|ssh|mms|svn"
-                            "|git|dict|nntp|irc|rsync|smb|apt)\\b://"));
+                            "|git|dict|nntp|ircs?|rsync|smb|apt)\\b://"));
   QString sDoc(pRawDoc->toPlainText());
   QRegularExpressionMatch match;
   int nIndex = 0;


### PR DESCRIPTION
Already implemented in Inyoka but not yet deployed.

Additionally:

Why is http/https and ftp/ftps seperate here?

https://github.com/inyokaproject/inyokaedit/blob/9dff8f0d12d05b1af82a22ef17dc707353464e4e/application/parser/parselinks.cpp#L111-L112

Couldn’t that be unified? If so, I’d add this to that PR.